### PR TITLE
Pass whole line into fish's complete

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,8 +14,8 @@ exports.activate = async context => {
   const source = {
     name: 'fish',
     doComplete: async opt => {
-      const cmd = opt.input.replace(/(["\s'$`\\])/g, '\\$1')
-      const result = await execPromise(`fish -c "complete -C${cmd}"`)
+      const cmd = opt.line.replace(/(['$`\\])/g, '\\$1')
+      const result = await execPromise(`fish -c "complete --do-complete='${cmd}'"`)
       return {
         items: result
           .stdout


### PR DESCRIPTION
Hi,

This PR passes the whole line to `complete`, so that fish can complete flags etc. I couldn't get the escaping to work properly with `-C`, so changed to `--do-complete=` instead.

Sending whole line even works with lines like `echo hello world; and ls -<TAB>`, but wouldn't work with multi-line statements, e.g.

```fish
some_command \
  --with-lots-of-options \
  --split-over-lin<TAB>
```